### PR TITLE
Update atlantic-1-install.sh

### DIFF
--- a/testnet/sei/atlantic-1-install.sh
+++ b/testnet/sei/atlantic-1-install.sh
@@ -27,6 +27,7 @@ rm -rf sei-chain
 git clone https://github.com/sei-protocol/sei-chain.git
 cd sei-chain || return
 git checkout 1.0.7beta-postfix
+if [ -f "/usr/local/bin/seid" ]; then rm /usr/local/bin/seid; fi
 make install
 seid version
 

--- a/testnet/sei/atlantic-1-install.sh
+++ b/testnet/sei/atlantic-1-install.sh
@@ -27,6 +27,8 @@ rm -rf sei-chain
 git clone https://github.com/sei-protocol/sei-chain.git
 cd sei-chain || return
 git checkout 1.0.7beta-postfix
+make build
+cp $HOME/go/bin/seid /usr/local/bin
 if [ -f "/usr/local/bin/seid" ]; then rm /usr/local/bin/seid; fi
 make install
 seid version


### PR DESCRIPTION
if older /usr/local/bin/seid file error script.